### PR TITLE
Add make targets for running tmpnb containers

### DIFF
--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-FROM jupyter/minimal-kernel:9cb6443840b2
+FROM jupyter/minimal-kernel:0017b56d93c9
 
 USER root
 
@@ -11,11 +11,6 @@ RUN apt-get update && \
 RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends git nodejs
-
-# Put the command in CMD instead of ENTRYPOINT because tmpnb invokes
-# using "/bin/sh -c"
-ENTRYPOINT ["tini", "--"]
-CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip=0.0.0.0"]
 
 USER jovyan
 

--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -12,6 +12,11 @@ RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends git nodejs
 
+# Put the command in CMD instead of ENTRYPOINT because tmpnb invokes
+# using "/bin/sh -c"
+ENTRYPOINT ["tini", "--"]
+CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip=0.0.0.0"]
+
 USER jovyan
 
 # install ipywidgets from github for now

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-.PHONY: help build certs run run-debug run-logging run-kernel-gateway kill dev-install dev debug _dev-install-ipywidgets
+.PHONY: help build certs \
+	run run-debug run-logging run-kernel-gateway \
+	run-tmpnb tmpnb-proxy tmpnb-proxy\
+	kill dev-install dev debug _dev-install-ipywidgets
 
 DASHBOARD_CONTAINER_NAME=dashboard-proxy
 DASHBOARD_IMAGE_NAME=jupyter-incubator/$(DASHBOARD_CONTAINER_NAME)
@@ -70,7 +73,66 @@ run-kernel-gateway:
 			$(KG_IMAGE_NAME); \
 	fi;
 
-kill:
+###### tmpnb
+
+MAX_LOG_SIZE:=50m
+MAX_LOG_ROLLOVER:=10
+
+token-check:
+	@test -n "$(TOKEN)" || \
+		(echo "ERROR: TOKEN not defined (make help)"; exit 1)
+
+tmpnb-proxy: PROXY_IMAGE?=jupyter/configurable-http-proxy@sha256:f84940db7ddf324e35f1a5935070e36832cc5c1f498efba4d69d7b962eec5d08
+tmpnb-proxy: token-check
+	@docker run -d \
+		--name=tmpnb-proxy \
+		--log-driver=json-file \
+		--log-opt max-size=$(MAX_LOG_SIZE) \
+		--log-opt max-file=$(MAX_LOG_ROLLOVER) \
+		-p 8080:8000 \
+		-e CONFIGPROXY_AUTH_TOKEN=$(TOKEN) \
+		$(PROXY_IMAGE) \
+			--default-target http://127.0.0.1:9999
+
+tmpnb-pool: TMPNB_IMAGE?=jupyter/tmpnb@sha256:54c39158eb83085bc6f445772b70d975f8b747af4159474f5407cfa2e0f390c7
+tmpnb-pool: POOL_SIZE?=2
+tmpnb-pool: MEMORY_LIMIT?=512m
+tmpnb-pool: IMAGE?=$(KG_IMAGE_NAME)
+tmpnb-pool: BRIDGE_IP=$(shell docker inspect --format='{{.NetworkSettings.Networks.bridge.Gateway}}' tmpnb-proxy)
+tmpnb-pool: token-check
+	@docker run -d \
+		--name=tmpnb-pool \
+		--log-driver=json-file \
+		--log-opt max-size=$(MAX_LOG_SIZE) \
+		--log-opt max-file=$(MAX_LOG_ROLLOVER) \
+		--net=container:tmpnb-proxy \
+		-e CONFIGPROXY_AUTH_TOKEN=$(TOKEN) \
+		-v /var/run/docker.sock:/docker.sock \
+		$(TMPNB_IMAGE) \
+		python orchestrate.py --image='$(IMAGE)' \
+			--container_ip=$(BRIDGE_IP) \
+			--pool_size=$(POOL_SIZE) \
+			--pool_name=tmpnb \
+			--cull_period=30 \
+			--cull_timeout=600 \
+			--max_dock_workers=16 \
+			--mem_limit=$(MEMORY_LIMIT) \
+			--redirect_uri=/api \
+			--command='jupyter kernelgateway \
+				--KernelGatewayApp.log_level=DEBUG \
+				--KernelGatewayApp.ip=0.0.0.0 \
+				--KernelGatewayApp.port={port} \
+				--KernelGatewayApp.base_url={base_path}'
+
+run-tmpnb: tmpnb-proxy tmpnb-pool
+
+kill-tmpnb:
+	@-docker rm -f tmpnb-pool tmpnb-proxy
+	@-docker rm -f $$(docker ps -a | grep 'tmp.' | awk '{print $$1}') 2> /dev/null
+
+###### end tmpnb
+
+kill: kill-tmpnb
 	-@docker rm -f $(DASHBOARD_CONTAINER_NAME) $(KG_CONTAINER_NAME)
 
 test: build

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: help build certs \
 	run run-debug run-logging run-kernel-gateway \
-	run-tmpnb tmpnb-proxy tmpnb-proxy\
+	run-tmpnb tmpnb-proxy tmpnb-pool kill-tmpnb token-check \
 	kill dev-install dev debug _dev-install-ipywidgets
 
 DASHBOARD_CONTAINER_NAME=dashboard-proxy
@@ -19,6 +19,8 @@ help:
 	@echo '               run - runs the dashboard proxy and kernel gateway containers'
 	@echo '         run-debug - run + debugging through node-inspector'
 	@echo '       run-logging - run + node network logging enabled'
+	@echo '         run-tmpnb - run tmpnb notebook service containers'
+	@echo '        kill-tmpnb - stops tmpnb notebook service containers'
 	@echo
 	@echo 'Dashboard proxy option defaults (via nconf):'
 	@cat config.json

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ MAX_LOG_SIZE:=50m
 MAX_LOG_ROLLOVER:=10
 
 token-check:
-	@test -n "$(TOKEN)" || \
-		(echo "ERROR: TOKEN not defined (make help)"; exit 1)
+	@test -n "$(TMPNB_PROXY_AUTH_TOKEN)" || \
+		(echo "ERROR: TMPNB_PROXY_AUTH_TOKEN not defined (make help)"; exit 1)
 
 tmpnb-proxy: PROXY_IMAGE?=jupyter/configurable-http-proxy@sha256:f84940db7ddf324e35f1a5935070e36832cc5c1f498efba4d69d7b962eec5d08
 tmpnb-proxy: token-check
@@ -90,7 +90,7 @@ tmpnb-proxy: token-check
 		--log-opt max-size=$(MAX_LOG_SIZE) \
 		--log-opt max-file=$(MAX_LOG_ROLLOVER) \
 		-p 8080:8000 \
-		-e CONFIGPROXY_AUTH_TOKEN=$(TOKEN) \
+		-e CONFIGPROXY_AUTH_TOKEN=$(TMPNB_PROXY_AUTH_TOKEN) \
 		$(PROXY_IMAGE) \
 			--default-target http://127.0.0.1:9999
 
@@ -106,7 +106,7 @@ tmpnb-pool: token-check
 		--log-opt max-size=$(MAX_LOG_SIZE) \
 		--log-opt max-file=$(MAX_LOG_ROLLOVER) \
 		--net=container:tmpnb-proxy \
-		-e CONFIGPROXY_AUTH_TOKEN=$(TOKEN) \
+		-e CONFIGPROXY_AUTH_TOKEN=$(TMPNB_PROXY_AUTH_TOKEN) \
 		-v /var/run/docker.sock:/docker.sock \
 		$(TMPNB_IMAGE) \
 		python orchestrate.py --image='$(IMAGE)' \

--- a/README.md
+++ b/README.md
@@ -29,29 +29,57 @@ For more details, including use cases and alternative deployments, see the [dash
 
 The demo requires Docker. A simple way to run [Docker](https://www.docker.com/) is to use [docker-machine](https://docs.docker.com/machine/get-started/).
 
-If you want to do a basic run with minimal HTTP traffic logging:
+### NodeJS application
 
-1. Run `make run` to build and launch two containers:
-    * kernel gateway container
-    * deployed dashboard container
+Choose one of the following ways to run both the node application container and a single kernel gateway container.
+
+To run with minimal HTTP logging:
+
+1. `make run`
 2. Visit `http://<external docker IP>:9700/notebooks/simple` to see a simple example notebook as a dashboard.
 3. To see another notebook as a dashboard:
     * Copy the `*.ipynb` file to the `data/` directory in the project root.
     * Run `make run` again -- this should rebuild the Docker image.
 
-If you want to enable remote debugging:
+To run with remote debugging enabled:
 
-1. Invoke `make run-debug` (instead of `make run`).
+1. `make run-debug`
 2. Open `http://<external docker IP>:9711/?ws=<external docker IP>:9711&port=5858` to access the `node-inspector` and commence debugging.
 
-If you want to enable debug logging:
+To run with debug-level logging enabled:
 
-1. Invoke `make run-logging` (instead `make run`).
+1. `make run-logging`
 2. Look at the server console.
 
-If you want to run with a self-signed certificate:
+To run with a self-signed certificate in the node application container, first create the certificates, then run one of the above commands while setting **both** the `HTTPS_KEY_FILE` and `HTTPS_CERT_FILE` environment variables:
 
 ```bash
 make certs
-HTTPS_KEY_FILE=../certs/server.pem HTTPS_CERT_FILE=../certs/server.pem make run
+make run \
+  HTTPS_KEY_FILE=certs/server.pem \
+  HTTPS_CERT_FILE=certs/server.pem
+```
+
+### tmpnb notebook service
+
+The following command will run the [tmpnb](https://github.com/jupyter/tmpnb) notebook service, including a configurable HTTP proxy container, a tmpnb orchestration container, and a pool of kernel gateway containers.  You must set the `TMPNB_PROXY_AUTH_TOKEN` environment variable.   The proxy and orchestration containers use the value as a token to authenticate requests between them.
+
+```bash
+make run-tmpnb \
+  TMPNB_PROXY_AUTH_TOKEN="$(openssl rand -base64 32)"
+```
+
+To run tmpnb with a pool of 5 kernel gateway containers, each with a memory limit of 1GB:
+
+```bash
+make run-tmpnb \
+  TMPNB_PROXY_AUTH_TOKEN="$(openssl rand -base64 32)" \
+  POOL_SIZE=5 \
+  MEMORY_LIMIT=1G
+```
+
+To stop all tmpnb containers:
+
+```bash
+make kill-tmpnb
 ```


### PR DESCRIPTION
Paired with @nitind to create some make targets that will run/kill tmpnb containers (proxy and pool).  Currently, the targets can be used to launch tmpnb separately from kernel_gateway container.  

To run tmpnb:

`make run-tmpnb TOKEN=mytoken`

To kill:

`make kill-tmpnb`

Have not changed the `make run` target -- it still runs kernel_gateway container.  We can look at switching to tmpnb (instead of kernel_gateway) once the node app has more support for running against tmpnb.

One final note: had to switch the ENTRYPOINT and CMD args in Dockerfile.kernel due to tmpnb always running command using `/bin/sh -c` (see https://github.com/jupyter/tmpnb/issues/209).