### PR TITLE
Lock lodash version to below 4.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
     "components"
   ],
   "dependencies": {
+    "lodash": ">= 3.5.0 < 4.0.0",
     "gridstack": "5bbd8d5f54edc48"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,7 @@ gulp.task('copy:components', function() {
             './bower_components/gridstack/dist/gridstack.min.css',
             './bower_components/jquery/dist/jquery.min.js',
             './bower_components/jquery-ui/jquery-ui.min.js',
-            './bower_components/lodash/dist/lodash.min.js'
+            './bower_components/lodash/lodash.min.js'
         ])
         .pipe(gulp.dest('./public/components'));
     var c2 = gulp.src([


### PR DESCRIPTION
lodash v4.0+ breaks gridstack rendering. For now,
lock to below 4.0.

Refs #10 