### PR TITLE
[Issue 69] Read default dashboard parameters from config.

### DIFF
--- a/app/handlebars-helpers.js
+++ b/app/handlebars-helpers.js
@@ -2,12 +2,17 @@
  * Copyright (c) Jupyter Development Team.
  * Distributed under the terms of the Modified BSD License.
  */
-commonmark = require('commonmark');
+var commonmark = require('commonmark');
+var config = require('./config');
 
 var reader = new commonmark.Parser();
 var writer = new commonmark.HtmlRenderer();
 
 module.exports = {
+    config: function(name) {
+        return config.get(name);
+    },
+
     mapCellType: function(cellType) {
         return cellType === 'markdown' ? 'text-cell' : 'code-cell';
     },

--- a/config.json
+++ b/config.json
@@ -34,4 +34,15 @@
     KG_AUTH_TOKEN: null
     // Kernel gateway base URL (gets appended to KERNEL_GATEWAY_URL)
     KG_BASE_URL: ""
+
+    //////////////////////////////
+    // Dashboard rendering options
+    //////////////////////////////
+
+    // Number of pixels between cells
+    DB_CELL_MARGIN: 10
+    // Number of pixels in each row
+    DB_DEFAULT_CELL_HEIGHT: 20
+    //Number of dashboard grid columns
+    DB_MAX_COLUMNS: 12
 }

--- a/less/login.less
+++ b/less/login.less
@@ -2,30 +2,42 @@
  * Copyright (c) Jupyter Development Team.
  * Distributed under the terms of the Modified BSD License.
  */
-.form-signin {
-  max-width: 330px;
-  padding: 15px;
-  margin: 0 auto;
-}
-.form-signin .form-control {
-  position: relative;
-  height: auto;
-  -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-          box-sizing: border-box;
-  padding: 10px;
-  font-size: 16px;
-}
-.form-signin .form-control:focus {
-  z-index: 2;
-}
-.form-signin input[type="text"] {
-  margin-bottom: -1px;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.form-signin input[type="password"] {
-  margin-bottom: 10px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+.login {
+    .form-signin {
+        max-width: 330px;
+        padding: 15px;
+        margin: 0 auto;
+
+        .form-control {
+            position: relative;
+            height: auto;
+            -webkit-box-sizing: border-box;
+               -moz-box-sizing: border-box;
+                    box-sizing: border-box;
+            padding: 10px;
+            font-size: 16px;
+
+            &:focus {
+                z-index: 2;
+            }
+        }
+
+        input {
+            &[type="text"] {
+                margin-bottom: -1px;
+                border-bottom-right-radius: 0;
+                border-bottom-left-radius: 0;
+            }
+
+            &[type="password"] {
+                margin-bottom: 10px;
+                border-top-left-radius: 0;
+                border-top-right-radius: 0;
+            }
+        }
+    }
+
+    .logged-in-header {
+        text-align: center;
+    }
 }

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -40,13 +40,13 @@ requirejs([
         // enable gridstack with parameters set by JS in the HTML page by
         // the backend
         var gridstack = $container.gridstack({
-            vertical_margin: Urth.cellMargin,
-            cell_height: Urth.defaultCellHeight,
-            width: Urth.maxColumns,
+            vertical_margin: Config.cellMargin,
+            cell_height: Config.defaultCellHeight,
+            width: Config.maxColumns,
             static_grid: true
         }).data('gridstack');
 
-        var halfMargin = Urth.cellMargin / 2;
+        var halfMargin = Config.cellMargin / 2;
         var styleRules = [
             {
                 selector: '#dashboard-container .grid-stack-item',

--- a/routes/login.js
+++ b/routes/login.js
@@ -21,8 +21,7 @@ var redirectBack = function(req, res) {
 router.get('/', function(req, res) {
     res.status(200);
     res.render('login', {
-        username: req.session.username,
-        authEnabled: config.get('AUTH_ENABLED')
+        username: req.session.username
     });
 });
 
@@ -36,20 +35,18 @@ router.post('/', urlencodedParser, function(req, res) {
     //if not logged in already
     if(!req.session.username) {
         //if username/password match
-        if(seedUsername === req.body.username && seedPassword === req.body.password) {
+        if (seedUsername === req.body.username &&
+            seedPassword === req.body.password) {
             req.session.username = req.body.username;
             redirectBack(req, res);
-        }
-        else {
+        } else {
             res.render('login', {
                 username: req.session.username,
-                authError: true,
-                authEnabled: config.get('AUTH_ENABLED')
+                authError: true
             });
         }
-    }
-    //already logged in
-    else {
+    } else {
+        //already logged in
         redirectBack(req, res);
     }
 });

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -11,7 +11,6 @@ var debug = require('debug')('dashboard-proxy:router');
 var nbstore = require('../app/notebook-store');
 var router = require('express').Router();
 
-var authEnabled = config.get('AUTH_ENABLED');
 var indexRegex = /index\.ipynb/i;
 
 function _renderList(req, res, list) {
@@ -19,7 +18,6 @@ function _renderList(req, res, list) {
     res.status(200);
     res.render('list', {
         username: req.session.username,
-        authEnabled: authEnabled,
         notebooks: list
     });
 }
@@ -74,8 +72,7 @@ router.get('/dashboards/*', function(req, res, next) {
                 res.render('dashboard', {
                     title: 'Dashboard',
                     notebook: notebook,
-                    username: req.session.username,
-                    authEnabled: config.get('AUTH_ENABLED')
+                    username: req.session.username
                 });
             },
             function error(err) {

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -46,17 +46,16 @@
 
 <script src="/components/require.js" data-main="/js/dashboard.js"></script>
 <script>
-    var Urth = window.Urth = window.Urth || {};
+    var Config = window.Config = window.Config || {};
     {{#if notebook.metadata.urth.dashboard}}
         {{#with notebook.metadata.urth.dashboard}}
-            Urth.cellMargin = {{cellMargin}};
-            Urth.defaultCellHeight = {{defaultCellHeight}};
-            Urth.maxColumns = {{maxColumns}};
+            Config.cellMargin = {{cellMargin}};
+            Config.defaultCellHeight = {{defaultCellHeight}};
+            Config.maxColumns = {{maxColumns}};
         {{/with}}
     {{else}}
-{{!-- TODO: Read these values from config (put in app.locals) --}}
-        Urth.cellMargin = 10;
-        Urth.defaultCellHeight = 20;
-        Urth.maxColumns = 12;
+        Config.cellMargin = {{{config 'DB_CELL_MARGIN'}}};
+        Config.defaultCellHeight = {{{config 'DB_DEFAULT_CELL_HEIGHT'}}};
+        Config.maxColumns = {{{config 'DB_MAX_COLUMNS'}}};
     {{/if}}
 </script>

--- a/views/login.handlebars
+++ b/views/login.handlebars
@@ -8,27 +8,24 @@
 
 {{> nav}}
 
-<div class="container">
-  {{#if authError}}
-  <div class="alert alert-danger" role="alert">
-    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-    <span class="sr-only">Error:</span>
-    Invalid login credentials.
-  </div>
-  {{/if}}
-  {{#if username}}
-  <center>
-    <h1>Logged in as, {{username}}.  Please log out first.</h1>
-  </center>
-  {{else}}
-  <form action="/login" method="post" class="form-signin">
-    <h2 class="form-signin-heading">Please sign in</h2>
-    <label for="username" class="sr-only">User Name</label>
-    <input type="text" name="username" id="username" class="form-control" placeholder="User Name" required autofocus>
-    <label for="password" class="sr-only">Password</label>
-    <input type="password" name="password" id="password" class="form-control" placeholder="Password" required>
-    <button class="btn btn-lg btn-primary btn-block" type="submit">Log in</button>
-  </form>
-  {{/if}}
-
-</div> <!-- /container -->
+<div class="login container">
+    {{#if authError}}
+        <div class="alert alert-danger" role="alert">
+            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+            <span class="sr-only">Error:</span>
+            Invalid login credentials.
+        </div>
+    {{/if}}
+    {{#if username}}
+        <h1 class="logged-in-header">Logged in as, {{username}}.  Please log out first.</h1>
+    {{else}}
+        <form action="/login" method="post" class="form-signin">
+            <h2 class="form-signin-heading">Please sign in</h2>
+            <label for="username" class="sr-only">User Name</label>
+            <input type="text" name="username" id="username" class="form-control" placeholder="User Name" required autofocus>
+            <label for="password" class="sr-only">Password</label>
+            <input type="password" name="password" id="password" class="form-control" placeholder="Password" required>
+            <button class="btn btn-lg btn-primary btn-block" type="submit">Log in</button>
+        </form>
+    {{/if}}
+</div>

--- a/views/partials/nav.handlebars
+++ b/views/partials/nav.handlebars
@@ -1,29 +1,29 @@
 <nav class="navbar navbar-default">
-  <div class="container-fluid">
-    <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <a class="navbar-brand" href="/">Jupyter Dashboard</a>
-    </div>
+    <div class="container-fluid">
+        <!-- Brand and toggle get grouped for better mobile display -->
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="/">Jupyter Dashboard</a>
+        </div>
 
-    {{#if authEnabled}}
-    <!-- Collect the nav links, forms, and other content for toggling -->
-    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-      <ul class="nav navbar-nav navbar-right">
-        {{#if username}}
-          <form class="navbar-form navbar-right" action="/logout" method="post">
-            <button type="submit" class="btn btn-link">Log Out, {{username}}</button>
-          </form>
-        {{else}}
-          <li><a href="/login">Sign In</a></li>
+        {{#if (config 'AUTH_ENABLED')}}
+            <!-- Collect the nav links, forms, and other content for toggling -->
+            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+                <ul class="nav navbar-nav navbar-right">
+                    {{#if username}}
+                        <form class="navbar-form navbar-right" action="/logout" method="post">
+                            <button type="submit" class="btn btn-link">Log Out, {{username}}</button>
+                        </form>
+                    {{else}}
+                        <li><a href="/login">Sign In</a></li>
+                    {{/if}}
+                </ul>
+            </div>
         {{/if}}
-      </ul>
-    </div><!-- /.navbar-collapse -->
-    {{/if}}
-  </div><!-- /.container-fluid -->
+    </div>
 </nav>

--- a/views/partials/welcome.handlebars
+++ b/views/partials/welcome.handlebars
@@ -1,5 +1,0 @@
-{{!
-    Copyright (c) Jupyter Development Team.
-    Distributed under the terms of the Modified BSD License.
-}}
-<p>Welcome to {{title }}</p>


### PR DESCRIPTION
Adds `config` handlebars helper and uses it to fill in default dashboard parameters. 

I went ahead and made use of this to remove the pervasive `authEnabled` flag being used on many template renders.

I also renamed the global `Urth` object to `Config` in the dashboard page since I was editing that template. This looked like the only use of "urth" outside of reading the notebook files.

Fixes #69 