### PR TITLE
[Dev] Remove livereload script from dev dependencies.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,6 @@
 var gulp = require('gulp'),
     nodemon = require('gulp-nodemon'),
     plumber = require('gulp-plumber'),
-    livereload = require('gulp-livereload'),
     less = require('gulp-less'),
     open = require('gulp-open'),
     webpack = require('webpack'),
@@ -114,13 +113,7 @@ var nodemonOptions = {
 };
 
 gulp.task('develop', ['build'], function () {
-    livereload.listen();
     nodemon(nodemonOptions).on('readable', function () {
-        this.stdout.on('data', function (chunk) {
-            if(/^Express server listening on port/.test(chunk)) {
-                livereload.changed(__dirname);
-            }
-        });
         this.stdout.pipe(process.stdout);
         this.stderr.pipe(process.stderr);
     });

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "css-loader": "^0.23.1",
     "gulp": "^3.9.0",
     "gulp-less": "^3.0.1",
-    "gulp-livereload": "^3.8.0",
     "gulp-nodemon": "^2.0.2",
     "gulp-open": "^1.0.0",
     "gulp-plumber": "^1.0.0",

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -8,9 +8,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width">
   <title>{{title }}</title>
-  {{#if ENV_DEVELOPMENT}}
-    <script src="http://localhost:35729/livereload.js"></script>
-  {{/if}}
 </head>
 <body>
 


### PR DESCRIPTION
We weren't actually using it, it didn't actually work, and it caused a client-side error when running in a container.