### PR TITLE
[Issue 67] Use jupyter-js-notebook for output area.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ var webpackStatsOptions = {
 gulp.task('webpack:components', function(done) {
     webpack({
             entry: {
-                'jupyter-js-output-area': './node_modules/jupyter-js-output-area/lib/index.js',
+                'jupyter-js-output-area': './node_modules/jupyter-js-notebook/lib/output-area/index.js',
                 'jupyter-js-services': './node_modules/jupyter-js-services/lib/index.js',
                 'jupyter-js-widgets': './node_modules/jupyter-js-widgets/index.js',
                 'urth-widgets': './node_modules/urth-widgets/index.js'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "font-awesome": "^4.5.0",
     "hjson": "^1.7.4",
     "http-proxy": "^1.12.0",
-    "jupyter-js-output-area": "^0.3.0",
+    "jupyter-js-notebook": "^0.5.10",
     "jupyter-js-services": "^0.3.0",
     "jupyter-js-widgets": "file:./ext/ipywidgets/ipywidgets",
     "morgan": "^1.6.1",


### PR DESCRIPTION
Resolves #67 