### PR TITLE
[issue: 82] %%javascript does not execute properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo '   logging-logging - demo + node network logging enabled'
 	@echo '              test - run unit tests'
 	@echo '  integration-test - run integration tests'
+	@echo '             clean - removes built Docker images, bower components, node modules, and certificates'
 	@echo
 	@echo 'Dashboard server option defaults (via nconf):'
 	@cat config.json
@@ -38,6 +39,7 @@ clean:
 	@-rm -rf public/components
 	@-rm -rf public/css
 	@-rm -rf public/urth_components
+	@-docker rmi -f $(KG_IMAGE_NAME) $(DASHBOARD_IMAGE_NAME)
 
 ############### Docker images
 
@@ -50,7 +52,7 @@ dashboard-server-image:
 	@docker build -f Dockerfile.server -t $(DASHBOARD_IMAGE_NAME) .
 
 images: kernel-gateway-image dashboard-server-image
-build: images
+build: images ext/ipywidgets ext/declarativewidgets
 
 kill:
 	@echo '-- Removing Docker containers'

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     // Mode in which the dashboard server express environment runs
     NODE_ENV: development
     // Interface on which the dashboard server listens
-    IP: 127.0.0.1
+    IP: 0.0.0.0
     // Port on which the dashboard server listens
     PORT: 3000
     // HTTPS_PORT, HTTPS Port on which the dashboard server listens

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ var webpackStatsOptions = {
 gulp.task('webpack:components', function(done) {
     webpack({
             entry: {
-                'jupyter-js-output-area': './node_modules/jupyter-js-output-area/lib/index.js',
+                'jupyter-js-notebook/output-area': './node_modules/jupyter-js-notebook/lib/output-area/index.js',
                 'jupyter-js-services': './node_modules/jupyter-js-services/lib/index.js',
                 'jupyter-js-widgets': './node_modules/jupyter-js-widgets/index.js',
                 'urth-widgets': './node_modules/urth-widgets/index.js'
@@ -48,7 +48,7 @@ gulp.task('webpack:components', function(done) {
             },
             externals: [
                 'jquery',
-                'jupyter-js-output-area',
+                'jupyter-js-notebook',
                 'jupyter-js-services',
                 'jupyter-js-widgets',
                 {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "font-awesome": "^4.5.0",
     "hjson": "^1.7.4",
     "http-proxy": "^1.12.0",
-    "jupyter-js-output-area": "^0.3.0",
+    "jupyter-js-notebook": "^0.5.0",
     "jupyter-js-services": "^0.3.0",
     "jupyter-js-widgets": "file:./ext/ipywidgets/ipywidgets",
     "morgan": "^1.6.1",

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -13,7 +13,7 @@ requirejs.config({
         'jquery-ui/widget': require.toUrl('/components/jquery-ui/widget.min'),
         'jquery-ui/resizable': require.toUrl('/components/jquery-ui/resizable.min'),
         'jquery-ui/draggable': require.toUrl('/components/jquery-ui/draggable.min'),
-        'jupyter-js-output-area': require.toUrl('/components/jupyter-js-output-area'),
+        'jupyter-js-notebook': require.toUrl('/components/jupyter-js-notebook'),
         'jupyter-js-services': require.toUrl('/components/jupyter-js-services'),
         'jupyter-js-widgets': require.toUrl('/components/jupyter-js-widgets'),
         'urth-widgets': require.toUrl('/components/urth-widgets')
@@ -23,7 +23,7 @@ requirejs.config({
 requirejs([
     'jquery',
     'gridstack-custom',
-    'jupyter-js-output-area',
+    'jupyter-js-notebook/output-area',
     'jupyter-js-widgets',
     'urth-widgets',
     'widget-manager',
@@ -131,7 +131,6 @@ requirejs([
     // initialize Declarative Widgets
     // NOTE: DeclWidgets adds 'urth_components/...' to this path
     DeclWidgets.init('/');
-
 
     // start a kernel
     Kernel.start().then(function(kernel) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -198,8 +198,13 @@ var killKernel = function(kernelId) {
         method: 'DELETE',
         headers: headers
     }, function(err, response, body) {
-        debug('PROXY: kill kernel response: ' +
-            response.statusCode + ' ' + response.statusMessage);
+        if (error) {
+          debug('PROXY: kill kernel error: ' + error);
+        }
+        else {
+          debug('PROXY: kill kernel response: ' +
+              response.statusCode + ' ' + response.statusMessage);
+        }
     });
 };
 


### PR DESCRIPTION
  Update from now-deprecated jupyter-js-output-area to jupyter-js-notebook,
  document the Makefile's clean target, and have the default config.json
  set to listen on all interfaces.
(c) Copyright IBM Corp. 2016